### PR TITLE
Update admin.php

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -24,7 +24,7 @@ function wamt_admin_settings_page(){
 	// If the adding data is not set, the value "mime_type_values" sets "empty".
 	$mime_type_values = "";
 	if(isset($settings['mime_type_values']) && !empty($settings['mime_type_values']))
-		$mime_type_values = unserialize($settings['mime_type_values']);
+		$mime_type_values = $settings['mime_type_values'];
 		
 	// When the adding data is saved (posted) at the setting menu, the data will update to the WordPress database after the security check
 	if(isset($_POST["wamt-form"]) && $_POST["wamt-form"]){
@@ -36,11 +36,11 @@ function wamt_admin_settings_page(){
 					foreach($mime_type_values as $m_type=>$m_value)
 					// "　" is the Japanese multi-byte space. If the character is found out, it automatically change the space. 
 						$mime_type_values[$m_type] = trim(str_replace("　", " ", $m_value));
-					$settings['mime_type_values'] = serialize($mime_type_values);
+					$settings['mime_type_values'] = $mime_type_values;
 				}
 			}
 			//else
-				//$mime_type_values = unserialize($settings['mime_type_values']);
+				//$mime_type_values = $settings['mime_type_values'];
 
 			if(!isset($settings['security_attempt_enable']))
 				$settings['security_attempt_enable'] = "no";
@@ -158,7 +158,7 @@ if(!empty($allowed_mime_values)){
 	if(is_multisite() && current_user_can('manage_network_options')){
 		$past_mime_type_values = "";
 		if(isset($past_settings['mime_type_values']))
-			$past_mime_type_values = unserialize($past_settings['mime_type_values']);
+			$past_mime_type_values = $past_settings['mime_type_values'];
 		if(!empty($past_mime_type_values)){
 
 ?>


### PR DESCRIPTION
did not work on 6.4.2 WordPress. 

AH01071: Got error 'PHP message: PHP Fatal error:  Uncaught TypeError: unserialize(): Argument #1 ($data) must be of type string, array given in /wp-content/plugins/wp-add-mime-types/includes/admin.php:27

The error message indicates that unserialize() is expecting a string as its argument, but it's receiving an array. To fix this issue, removed unserialize() as if it's already an array, so it will be assigned directly to $mime_type_values